### PR TITLE
Allowed PHP 5.3 and PHP 5.4 to fail. Also removed hhvm-nightly from t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ php:
   - 5.6
   - 7
   - hhvm
-  - hhvm-nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7
+    - php: 5.3
+    - php: 5.4
     - php: hhvm
-    - php: hhvm-nightly
 
 before_script:
   - composer self-update


### PR DESCRIPTION
…he list of builds. PHP 7 is no longer allowed to fail. This closes issue #7.
