### PR TITLE
Add Test\Bag and improve TestInterface

### DIFF
--- a/src/Analytics/AnalyticsInterface.php
+++ b/src/Analytics/AnalyticsInterface.php
@@ -4,5 +4,4 @@ namespace Phpab\Phpab\Analytics;
 
 interface AnalyticsInterface
 {
-
 }

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -10,7 +10,6 @@ use Phpab\Phpab\Test\TestInterface;
 
 interface EngineInterface
 {
-
     /**
      * Gets the storage where information about
      * the users participation is stored.

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -51,21 +51,14 @@ interface EngineInterface
     /**
      * Adds a test to the Engine
      *
-     * @param \Phpab\Phpab\Test\TestInterface                 $test
-     * @param array                                           $options
-     * @param \Phpab\Phpab\Participation\FilterInterface|null $participationFilter
-     * @param \Phpab\Phpab\Variant\ChooserInterface|null      $variantChooser
+     * @param \Phpab\Phpab\Test\TestInterface $test
+     * @param array                           $options
      *
      * @throws TestCollisionException
      *
      * @return null
      */
-    public function addTest(
-        TestInterface $test,
-        $options = [],
-        FilterInterface $participationFilter = null,
-        ChooserInterface $variantChooser = null
-    );
+    public function addTest(TestInterface $test, $options = []);
 
     /**
      * Starts the tests

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -5,10 +5,8 @@ namespace Phpab\Phpab\Engine;
 use Phpab\Phpab\Analytics\AnalyticsInterface;
 use Phpab\Phpab\Exception\TestCollisionException;
 use Phpab\Phpab\Exception\TestNotFoundException;
-use Phpab\Phpab\Participation\FilterInterface;
 use Phpab\Phpab\Participation\StorageInterface;
 use Phpab\Phpab\Test\TestInterface;
-use Phpab\Phpab\Variant\ChooserInterface;
 
 interface EngineInterface
 {

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -5,8 +5,10 @@ namespace Phpab\Phpab\Engine;
 use Phpab\Phpab\Analytics\AnalyticsInterface;
 use Phpab\Phpab\Exception\TestCollisionException;
 use Phpab\Phpab\Exception\TestNotFoundException;
+use Phpab\Phpab\Participation\FilterInterface;
 use Phpab\Phpab\Participation\StorageInterface;
 use Phpab\Phpab\Test\TestInterface;
+use Phpab\Phpab\Variant\ChooserInterface;
 
 interface EngineInterface
 {
@@ -49,11 +51,21 @@ interface EngineInterface
     /**
      * Adds a test to the Engine
      *
-     * @param \Phpab\Phpab\Test\TestInterface $test
-     * 
+     * @param \Phpab\Phpab\Test\TestInterface                 $test
+     * @param array                                           $options
+     * @param \Phpab\Phpab\Participation\FilterInterface|null $participationFilter
+     * @param \Phpab\Phpab\Variant\ChooserInterface|null      $variantChooser
+     *
      * @throws TestCollisionException
+     *
+     * @return null
      */
-    public function addTest(TestInterface $test);
+    public function addTest(
+        TestInterface $test,
+        $options = [],
+        FilterInterface $participationFilter = null,
+        ChooserInterface $variantChooser = null
+    );
 
     /**
      * Starts the tests

--- a/src/Test/Bag.php
+++ b/src/Test/Bag.php
@@ -40,8 +40,7 @@ class Bag
         $options = [],
         FilterInterface $participationFilter,
         ChooserInterface $variantChooser
-    )
-    {
+    ) {
         $this->test = $test;
         $this->options = $options;
         $this->participationFilter = $participationFilter;
@@ -93,5 +92,4 @@ class Bag
     {
         return $this->variantChooser;
     }
-
 }

--- a/src/Test/Bag.php
+++ b/src/Test/Bag.php
@@ -31,15 +31,15 @@ class Bag
      * Bag constructor.
      *
      * @param \Phpab\Phpab\Test\TestInterface            $test The test
-     * @param array                                      $options Additional options
      * @param \Phpab\Phpab\Participation\FilterInterface $participationFilter
      * @param \Phpab\Phpab\Variant\ChooserInterface      $variantChooser
+     * @param array                                      $options Additional options
      */
     public function __construct(
         TestInterface $test,
-        $options = [],
         FilterInterface $participationFilter,
-        ChooserInterface $variantChooser
+        ChooserInterface $variantChooser,
+        $options = []
     ) {
         $this->test = $test;
         $this->options = $options;

--- a/src/Test/Bag.php
+++ b/src/Test/Bag.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Phpab\Phpab\Test;
+
+use Phpab\Phpab\Participation\FilterInterface;
+use Phpab\Phpab\Variant\ChooserInterface;
+
+class Bag
+{
+    /**
+     * @var \Phpab\Phpab\Test\TestInterface
+     */
+    private $test;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var \Phpab\Phpab\Participation\FilterInterface
+     */
+    private $participationFilter;
+
+    /**
+     * @var \Phpab\Phpab\Variant\ChooserInterface
+     */
+    private $variantChooser;
+
+    /**
+     * Bag constructor.
+     *
+     * @param \Phpab\Phpab\Test\TestInterface            $test The test
+     * @param array                                      $options Additional options
+     * @param \Phpab\Phpab\Participation\FilterInterface $participationFilter
+     * @param \Phpab\Phpab\Variant\ChooserInterface      $variantChooser
+     */
+    public function __construct(
+        TestInterface $test,
+        $options = [],
+        FilterInterface $participationFilter,
+        ChooserInterface $variantChooser
+    )
+    {
+        $this->test = $test;
+        $this->options = $options;
+        $this->participationFilter = $participationFilter;
+        $this->variantChooser = $variantChooser;
+    }
+
+    /**
+     * Get the Test from the Bag
+     *
+     * @return TestInterface
+     */
+    public function getTest()
+    {
+        return $this->test;
+    }
+
+    /**
+     * Get all Options for the Test.
+     *
+     * Options can be used for data which is not mandatory and
+     * can be Implementation specific. Like Google-Experiments ID
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Get the Participation Strategy
+     *
+     * @return FilterInterface
+     */
+    public function getParticipationFilter()
+    {
+        return $this->participationFilter;
+    }
+
+    /**
+     * Get the Variant Chooser.
+     *
+     * The Variant Chooser chooses the variant after the
+     * Strategy allowed the user to participate in the test.
+     *
+     * @return ChooserInterface
+     */
+    public function getVariantChooser()
+    {
+        return $this->variantChooser;
+    }
+
+}

--- a/src/Test/TestInterface.php
+++ b/src/Test/TestInterface.php
@@ -2,13 +2,10 @@
 
 namespace Phpab\Phpab\Test;
 
-use Phpab\Phpab\Participation\FilterInterface;
-use Phpab\Phpab\Variant\ChooserInterface;
 use Phpab\Phpab\Variant\VariantInterface;
 
 interface TestInterface
 {
-
     /**
      * Get the identifier for this test
      *
@@ -28,34 +25,7 @@ interface TestInterface
      *
      * @param string $variant The variants Identifier
      *
-     * @return mixed
+     * @return VariantInterface
      */
     public function getVariant($variant);
-
-    /**
-     * Get all Options for the Test.
-     *
-     * Options can be used for data which is not mandatory and
-     * can be Implementation specific. Like Google-Experiments ID
-     *
-     * @return array
-     */
-    public function getOptions();
-
-    /**
-     * Get the Participation Strategy
-     *
-     * @return FilterInterface
-     */
-    public function getParticipationFilter();
-
-    /**
-     * Get the Variant Chooser.
-     *
-     * The Variant Chooser chooses the variant after the
-     * Strategy allowed the user to participate in the test.
-     *
-     * @return ChooserInterface
-     */
-    public function getVariantChooser();
 }

--- a/tests/Test/BagTest.php
+++ b/tests/Test/BagTest.php
@@ -7,7 +7,6 @@ use Phpab\Phpab\Variant\ChooserInterface;
 
 class BagTest extends \PHPUnit_Framework_TestCase
 {
-
     private $test;
     private $participationFilter;
     private $variantChooser;
@@ -78,5 +77,4 @@ class BagTest extends \PHPUnit_Framework_TestCase
         // Assert
         $this->assertInstanceOf(ChooserInterface::class, $chooser);
     }
-
 }

--- a/tests/Test/BagTest.php
+++ b/tests/Test/BagTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Phpab\Phpab\Test;
+
+use Phpab\Phpab\Participation\FilterInterface;
+use Phpab\Phpab\Variant\ChooserInterface;
+
+class BagTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $test;
+    private $participationFilter;
+    private $variantChooser;
+
+    public function setUp()
+    {
+        $this->test = $this->getMock(TestInterface::class);
+        $this->participationFilter = $this->getMock(FilterInterface::class);
+        $this->variantChooser = $this->getMock(ChooserInterface::class);
+    }
+
+    public function testGetTest()
+    {
+        // Arrange
+        $bag = new Bag($this->test, $this->participationFilter, $this->variantChooser, []);
+
+        // Act
+        $test = $bag->getTest();
+
+        // Assert
+        $this->assertInstanceOf(TestInterface::class, $test);
+    }
+
+    public function testGetOptions()
+    {
+        // Arrange
+        $bag = new Bag($this->test, $this->participationFilter, $this->variantChooser, ['Walter']);
+
+        // Act
+        $options = $bag->getOptions();
+
+        // Assert
+        $this->assertEquals(['Walter'], $options);
+    }
+
+    public function testGetOptionsIfNotProvided()
+    {
+        // Arrange
+        $bag = new Bag($this->test, $this->participationFilter, $this->variantChooser);
+
+        // Act
+        $options = $bag->getOptions();
+
+        // Assert
+        $this->assertEquals([], $options);
+    }
+
+    public function testGetParticipationFilter()
+    {
+        // Arrange
+        $bag = new Bag($this->test, $this->participationFilter, $this->variantChooser);
+
+        // Act
+        $filter = $bag->getParticipationFilter();
+
+        // Assert
+        $this->assertInstanceOf(FilterInterface::class, $filter);
+    }
+
+    public function testGetVariantChooser()
+    {
+        // Arrange
+        $bag = new Bag($this->test, $this->participationFilter, $this->variantChooser);
+
+        // Act
+        $chooser = $bag->getVariantChooser();
+
+        // Assert
+        $this->assertInstanceOf(ChooserInterface::class, $chooser);
+    }
+
+}


### PR DESCRIPTION
The TestInterface is more simple now and responsibilities are better.

Benefits
1. The Test does not need to know about Filter / Chooser
2. Adding a Test to Engine is more simple
3. Filter/Chooser can be set once per Engine
4. Filter/Chooser can be set once per Engine

Test for the Bag implementation need to be added.
We do not need an interface for that because the only Class that is aware of the Bag is the Engine itself.
Different Engines can implement different Bags.

Maybe we could add GoogleExperimentsEngine then (analytics is already in the scope of the engine) so the Engine can implement its own Bag and require "ExperimentsID" per Test ??

WDYT
