### PR TITLE
[PoC][RFC] "Analytics" implementation

### DIFF
--- a/example/bootstrap.php
+++ b/example/bootstrap.php
@@ -1,28 +1,41 @@
 <?php
 
-// this is pseude code because it's not implemented yet and we do not have tests
+require __DIR__.'/../vendor/autoload.php';
 
-$app = new myShinyWhateverFramework();
+$participationViewHelper = new \PhpAb\Helper\ParticipationChecker();
+$googleHelper = new \PhpAb\Helper\GoogleExperimentsHelper();
 
-$engine = new \PhpAb\Engine(
-    new \PhpAb\Storage\CookieStorage(),
-    new \PhpAb\Analytics\GoogleExperiments('UA-asfsafsaf')
-);
+$dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+$dispatcher->addSubscriber($participationViewHelper);
+$dispatcher->addSubscriber($googleHelper);
 
-$test = new \PhpAb\Test(
-    'foo_test',
-    new \PhpAb\ParticipationStrategy\LotteryParticipationStrategy(0.1),
-    new \PhpAb\VariantChooser\RandomVariantChooser()
-);
-$test->addVariant(new \PhpAb\DifferentThemeVariant('different_checkout_steps', $app->getEventManager()));
+$engine = new \PhpAb\Engine\Engine($dispatcher);
+$engine->run();
 
-// Add some tests
-$engine->addTest($test);
+// lets get a nicer name in our view
+$abUser = $participationViewHelper;
 
-// Start testing. Must occur before the EventCycle of the app starts
-$engine->start();
 
-// Start the app
-// The Events of the app fire
-// e.g. EVENT_MERGE_CONFIG where our Variant listens to
-$app->run();
+// Then later in the View
+if($abUser->participatesInVariantForTest('test1', 'variant1')) {
+    echo 'yay, participates in variant1 for test1';
+} elseif ($abUser->participatesInVariantForTest('test1', 'variant2') ){
+    echo 'yay, participates in variant2 for test1';
+} else {
+    echo 'old business case';
+}
+
+echo '<br/>';
+echo '<br/>';
+
+if($abUser->participatesInVariantForTest('test2', 'variant1')) {
+    echo 'yay, participates in variant1 for test2';
+} else {
+    echo 'old business case for test2';
+}
+
+echo '<br/>';
+echo '<br/>';
+
+// get the data from a different driver
+echo $googleHelper->getScript();

--- a/src/Analytics/AnalyticsInterface.php
+++ b/src/Analytics/AnalyticsInterface.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PhpAb\Analytics;
-
-interface AnalyticsInterface
-{
-}

--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace PhpAb\Engine;
+
+use PhpAb\Event\ParticipationEvent;
+use PhpAb\Exception\TestCollisionException;
+use PhpAb\Exception\TestNotFoundException;
+use PhpAb\Participation\StorageInterface;
+use PhpAb\Test\TestInterface;
+use PhpAb\Variant\SimpleVariant;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use PhpAb\Test\Test;
+
+class Engine implements EngineInterface
+{
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStorage()
+    {
+        // TODO: Implement getStorage() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTests()
+    {
+        // TODO: Implement getTests() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTest($test)
+    {
+        // TODO: Implement getTest() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addTest(TestInterface $test, $options = [])
+    {
+        // TODO: Implement addTest() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function run()
+    {
+        if(0 === rand(0,2)) {
+            // dummy test
+            // we ran the test already
+            $test = new Test('test1');
+            $variant = new SimpleVariant('variant1');
+            $this->dispatcher->dispatch(
+                ParticipationEvent::PARTICIPATION,
+                new ParticipationEvent($test, $variant, true)
+            );
+        }
+        
+        $test2 = new Test('test2');
+        $variant3 = new SimpleVariant('variant3');
+        $this->dispatcher->dispatch(
+            ParticipationEvent::PARTICIPATION,
+            new ParticipationEvent($test2, $variant3, true)
+        );
+    }
+}

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -19,16 +19,6 @@ interface EngineInterface
     public function getStorage();
 
     /**
-     * Get the Analytics instance which handles the Events
-     * that occur during the test process.
-     *
-     * This is like a EventListener with limited API
-     *
-     * @return AnalyticsInterface
-     */
-    public function getAnalytics();
-
-    /**
      * Get all tests for the engine
      *
      * @return TestInterface[]|array
@@ -63,5 +53,5 @@ interface EngineInterface
      *
      * @return null
      */
-    public function start();
+    public function run();
 }

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpAb\Event;
+
+class EventDispatcher implements EventDispatcherInterface
+{
+    public function __construct()
+    {
+        
+    }
+
+    public function dispatch($event, $data)
+    {
+        // TODO: Implement dispatch() method.
+    }
+}

--- a/src/Event/Events.php
+++ b/src/Event/Events.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpAb\Event;
+
+final class Events
+{
+    const REGISTER_NEW_PARTICIPATION = 'phpab.participation.register.new';
+    const REGISTER_EXISTING_PARTICIPATION = 'phpab.participation.register.existing';
+}

--- a/src/Event/ParticipationEvent.php
+++ b/src/Event/ParticipationEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace PhpAb\Event;
+
+use PhpAb\Test\TestInterface;
+use PhpAb\Variant\VariantInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class ParticipationEvent extends Event
+{
+    const PARTICIPATION = 'phpab.participation';
+
+    /**
+     * @var \PhpAb\Test\TestInterface
+     */
+    private $test;
+
+    /**
+     * @var \PhpAb\Variant\VariantInterface
+     */
+    private $variant;
+
+    /**
+     * @var boolean
+     */
+    private $isNew;
+
+    public function __construct(TestInterface $test, VariantInterface $variant, $isNew)
+    {
+        $this->test = $test;
+        $this->variant = $variant;
+        $this->isNew = $isNew;
+    }
+
+    /**
+     * @return TestInterface
+     */
+    public function getTest()
+    {
+        return $this->test;
+    }
+
+    /**
+     * @return VariantInterface
+     */
+    public function getVariant()
+    {
+        return $this->variant;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isIsNew()
+    {
+        return $this->isNew;
+    }
+
+}

--- a/src/Helper/GoogleExperimentsHelper.php
+++ b/src/Helper/GoogleExperimentsHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PhpAb\Helper;
+
+use PhpAb\Event\ParticipationEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class GoogleExperimentsHelper implements EventSubscriberInterface
+{
+    /**
+     * @var ParticipationEvent[]
+     */
+    private $participations = [];
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            ParticipationEvent::PARTICIPATION => 'onParticipationEvent',
+        ];
+    }
+
+    public function onParticipationEvent(ParticipationEvent $event)
+    {
+        $this->participations[$event->getTest()->getIdentifier()] = $event;
+    }
+
+    public function getScript()
+    {
+        $script = '&lt;script&gt;';
+        $script .= '{foo: bar, do: while}';
+        $script .= '&lt;/script&gt;';
+
+        return $script;
+    }
+
+    public function getData()
+    {
+        // sample method. Maybe to pass it to a template-engine or so
+    }
+
+    public function whatEverFunction()
+    {
+        // Do whatever you want
+    }
+}

--- a/src/Helper/ParticipationChecker.php
+++ b/src/Helper/ParticipationChecker.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PhpAb\Helper;
+
+use PhpAb\Event\ParticipationEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ParticipationChecker implements EventSubscriberInterface
+{
+    /**
+     * @var ParticipationEvent[]
+     */
+    private $participations = [];
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            ParticipationEvent::PARTICIPATION => 'onParticipationEvent',
+        ];
+    }
+
+    public function onParticipationEvent(ParticipationEvent $event)
+    {
+        $this->participations[$event->getTest()->getIdentifier()] = $event;
+    }
+
+    public function participatesInTest($testIdentifier)
+    {
+        if(isset($this->participations[$testIdentifier])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function participatesInVariant($variantIdentifier)
+    {
+        var_dump($this->participations);
+        foreach($this->participations as $testEvent) {
+            if($testEvent->getVariant()->getIdentifier() === $variantIdentifier) {
+                return  true;
+            }
+        }
+
+        return false;
+    }
+
+    public function participatesInVariantForTest($testIdentifier, $variantIdentifier)
+    {
+        if(! $this->participatesInTest($testIdentifier)) {
+            return false;
+        }
+
+        $variant = $this->participations[$testIdentifier]->getVariant();
+        if($variant->getIdentifier() === $variantIdentifier) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Test/Test.php
+++ b/src/Test/Test.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpAb\Test;
+
+use PhpAb\Variant\VariantInterface;
+
+class Test implements TestInterface
+{
+    public function __construct($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getVariants()
+    {
+        // TODO: Implement getVariants() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getVariant($variant)
+    {
+        // TODO: Implement getVariant() method.
+    }
+
+}


### PR DESCRIPTION
**No Code review please. it's only a PoC**

see `examples/bootstrap.php` for a working example.

Hey guys. We already talked about it and I talked with some other guys.
I think it's best to solve the Analytics Problem with an event system.

I did a PoC here and it works out nice. **The final Result will be much better**
## Requirements
### An Interface is dangerous here

If we have an Interface here we could NEVER EVER add methods to it because Userland depends on that interface and we typehinted it. It we change it we will break all implementations.
### Multiple "Analytics" need to fetch different data formats

We could leave this open for implementation land.
### Multiply "Analytics" could be attached at once

We talked about it already and that seemed to not be the case. I agreed.
But after thinking a lot I decided to extend the scope here.

We can use different Collectors/Helpers to fetch the data, process it, and use it in different places.

In my example I mocked
- Google Experiments
- A ViewHelper which could later be used with Smarty/Twig/Blade/Plates/PHP-Template
## Problems now
### Coupled to the Symfony EventDispatcher

This is just a Proof of Concept. If we decide to use EventDispatching we would build a small set of 2 Interfaces (like mentioned here http://php-and-symfony.matthiasnoback.nl/2014/08/symfony2-decoupling-your-event-system/).
**By default** we will provide one dead simple implementation (a few lines of code. Mainly a foreach loop ;-))

For the Integrations we could provide
- SymfonyEventBridge as suggested package and require it in the symfony bundle
- Same for zend
- A Bridge to The EventManager of thePhpLeague

this way we would stay totally decoupled.
## Summary

In fact @waltertamboer built his own mini event-listener here: https://github.com/phpab/phpab/blob/master/src/Analytics/AnalyticsInterface.php
A full EventDispatcher system provides much more flexibilty and easier extensibility.

The implementation of @pachico (https://github.com/pachico/abtest/blob/master/src/tracking/trackinginterface.php) seems to be a bit more simple and less verbose. But it's better extendable it we want to add new events.

---

I am so hard :100:  :+1: for EventSystem.

What do you think?
## GIMICK

We can easy resolve the analyzers out of a tagged dependency injection container as e.g. symfony provides.

We can use the frameworks own EventSystem. As it's events and not only analytics we can do thinks like

> Before TestA runs check the dueDate from the options of the TestBag. When dueDate passed deactivate the test and send notification to the admin that it can be removed. In his sleep switch automatically to the test which had the best performance during the testing period.
## Implications

If we go this way (i hope so) this is the TODO list.
- [x] tests
- [x] remove EngineInterface::getAnalytics
- [x] write minimal Event System
- [ ] write Event Interfaces for abstraction (allows neatless integration wit Symfony/Event or Zend/EventManager **suggested packages**
