### PR TITLE
Feature/event system

### DIFF
--- a/example/bootstrap.php
+++ b/example/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 // Engine and Analytics have to be implemented before this works
 
 $engine = new \PhpAb\Engine(

--- a/example/bootstrap.php
+++ b/example/bootstrap.php
@@ -1,28 +1,24 @@
 <?php
 
-// this is pseude code because it's not implemented yet and we do not have tests
-
-$app = new myShinyWhateverFramework();
+// Engine and Analytics have to be implemented before this works
 
 $engine = new \PhpAb\Engine(
-    new \PhpAb\Storage\CookieStorage(),
-    new \PhpAb\Analytics\GoogleExperiments('UA-asfsafsaf')
+    new \PhpAb\Storage\Session()
 );
 
 $test = new \PhpAb\Test(
     'foo_test',
-    new \PhpAb\ParticipationStrategy\LotteryParticipationStrategy(0.1),
-    new \PhpAb\VariantChooser\RandomVariantChooser()
+    new \PhpAb\Participation\PercentageFilter(10),
+    new \PhpAb\Variant\RandomChooser()
 );
-$test->addVariant(new \PhpAb\DifferentThemeVariant('different_checkout_steps', $app->getEventManager()));
+
+$test->addVariant(new \PhpAb\Variant\SimpleVariant('_control'));
+$test->addVariant(new \PhpAb\Variant\SimpleVariant('variantA'));
+$test->addVariant(new \PhpAb\Variant\SimpleVariant('variantB'));
+$test->addVariant(new \PhpAb\Variant\SimpleVariant('variantC'));
 
 // Add some tests
 $engine->addTest($test);
 
 // Start testing. Must occur before the EventCycle of the app starts
 $engine->start();
-
-// Start the app
-// The Events of the app fire
-// e.g. EVENT_MERGE_CONFIG where our Variant listens to
-$app->run();

--- a/src/Analytics/AnalyticsInterface.php
+++ b/src/Analytics/AnalyticsInterface.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PhpAb\Analytics;
-
-interface AnalyticsInterface
-{
-}

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -2,7 +2,6 @@
 
 namespace PhpAb\Engine;
 
-use PhpAb\Analytics\AnalyticsInterface;
 use PhpAb\Exception\TestCollisionException;
 use PhpAb\Exception\TestNotFoundException;
 use PhpAb\Participation\StorageInterface;
@@ -17,16 +16,6 @@ interface EngineInterface
      * @return StorageInterface
      */
     public function getStorage();
-
-    /**
-     * Get the Analytics instance which handles the Events
-     * that occur during the test process.
-     *
-     * This is like a EventListener with limited API
-     *
-     * @return AnalyticsInterface
-     */
-    public function getAnalytics();
 
     /**
      * Get all tests for the engine

--- a/src/Event/Dispatcher.php
+++ b/src/Event/Dispatcher.php
@@ -2,8 +2,6 @@
 
 namespace PhpAb\Event;
 
-use Event\SubscriberInterface;
-
 class Dispatcher implements DispatcherInterface
 {
     private $listeners = [];
@@ -13,22 +11,21 @@ class Dispatcher implements DispatcherInterface
         $this->listeners[$eventName][] = $callable;
     }
 
-    public function addSubscriber(EventSubscriberInterface $subscriber)
+    public function addSubscriber(SubscriberInterface $subscriber)
     {
-        foreach($subscriber->getSubscribedEvents() as $eventName => $callable) {
+        foreach ($subscriber->getSubscribedEvents() as $eventName => $callable) {
             $this->addListener($eventName, $callable);
         }
     }
 
     public function dispatch($event, $options)
     {
-        if(! array_key_exists($event, $this->listeners)) {
+        if (! array_key_exists($event, $this->listeners)) {
             // no callbacks given for this event
             return;
         }
 
-        foreach($this->listeners[$event] as $callable)
-        {
+        foreach ($this->listeners[$event] as $callable) {
             call_user_func($callable, $options);
         }
     }

--- a/src/Event/Dispatcher.php
+++ b/src/Event/Dispatcher.php
@@ -4,13 +4,28 @@ namespace PhpAb\Event;
 
 class Dispatcher implements DispatcherInterface
 {
+    /**
+     * @var array An array holding the Listeners for a given event.
+     *            The format looks like
+     *            [
+     *              'eventname' => [callable, callable, callable],
+     *              'eventname2' => [callable, callable, callable]
+     *            ]
+     */
     private $listeners = [];
 
+    /**
+     * @param          $eventName The name of the event to listen for
+     * @param callable $callable  The Callable to execute once the event takes place
+     */
     public function addListener($eventName, callable $callable)
     {
         $this->listeners[$eventName][] = $callable;
     }
 
+    /**
+     * @param \PhpAb\Event\SubscriberInterface $subscriber The subscriber which can subscribe to multiple events
+     */
     public function addSubscriber(SubscriberInterface $subscriber)
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $callable) {
@@ -18,6 +33,9 @@ class Dispatcher implements DispatcherInterface
         }
     }
 
+    /**
+     * @inheritdoc
+     */
     public function dispatch($event, $options)
     {
         if (! array_key_exists($event, $this->listeners)) {
@@ -25,6 +43,8 @@ class Dispatcher implements DispatcherInterface
             return;
         }
 
+        // Iterate through each Listener attached to this event
+        // and call it with the given options
         foreach ($this->listeners[$event] as $callable) {
             call_user_func($callable, $options);
         }

--- a/src/Event/Dispatcher.php
+++ b/src/Event/Dispatcher.php
@@ -15,7 +15,7 @@ class Dispatcher implements DispatcherInterface
     private $listeners = [];
 
     /**
-     * @param          $eventName The name of the event to listen for
+     * @param string   $eventName The name of the event to listen for
      * @param callable $callable  The Callable to execute once the event takes place
      */
     public function addListener($eventName, callable $callable)

--- a/src/Event/Dispatcher.php
+++ b/src/Event/Dispatcher.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PhpAb\Event;
+
+use Event\SubscriberInterface;
+
+class Dispatcher implements DispatcherInterface
+{
+    private $listeners = [];
+
+    public function addListener($eventName, callable $callable)
+    {
+        $this->listeners[$eventName][] = $callable;
+    }
+
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        foreach($subscriber->getSubscribedEvents() as $eventName => $callable) {
+            $this->addListener($eventName, $callable);
+        }
+    }
+
+    public function dispatch($event, $options)
+    {
+        if(! array_key_exists($event, $this->listeners)) {
+            // no callbacks given for this event
+            return;
+        }
+
+        foreach($this->listeners[$event] as $callable)
+        {
+            call_user_func($callable, $options);
+        }
+    }
+}

--- a/src/Event/DispatcherInterface.php
+++ b/src/Event/DispatcherInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpAb\Event;
+
+interface DispatcherInterface
+{
+    public function dispatch($event, $options);
+}

--- a/src/Event/DispatcherInterface.php
+++ b/src/Event/DispatcherInterface.php
@@ -2,7 +2,17 @@
 
 namespace PhpAb\Event;
 
+/**
+ * The Dispatcher dispatches/fires events that happens
+ * in the application and dispatches the assigned callbacks.
+ */
 interface DispatcherInterface
 {
+    /**
+     * Dispatches an event with some options
+     *
+     * @param $event The name of the Event which should be dispatched
+     * @param $options The options that should get passed to the callback
+     */
     public function dispatch($event, $options);
 }

--- a/src/Event/ParticipationEvent.php
+++ b/src/Event/ParticipationEvent.php
@@ -5,9 +5,18 @@ namespace PhpAb\Event;
 use PhpAb\Test\TestInterface;
 use PhpAb\Variant\VariantInterface;
 
+/**
+ * Class ParticipationEvent
+ *
+ * Holds information about a participation event which is needed for
+ * further processing.
+ */
 class ParticipationEvent
 {
-
+    /**
+     * This Event will be fired once a participation
+     * for a user is registered.
+     */
     const PARTICIPATION = 'phpab.participation';
 
     /**
@@ -25,6 +34,12 @@ class ParticipationEvent
      */
     private $isNew;
 
+    /**
+     * @param \PhpAb\Test\TestInterface       $test The Test the participation was registered for
+     * @param \PhpAb\Variant\VariantInterface $variant The Variant the user is associated with
+     * @param boolean                         $isNew  Indicates weather the user is new or has an old participation
+     *                                                from the storage.
+     */
     public function __construct(TestInterface $test, VariantInterface $variant, $isNew)
     {
         $this->test = $test;
@@ -33,6 +48,8 @@ class ParticipationEvent
     }
 
     /**
+     * Get the Test the participation was registered for
+     *
      * @return TestInterface
      */
     public function getTest()
@@ -41,6 +58,8 @@ class ParticipationEvent
     }
 
     /**
+     * Get the Variant the user is associated with
+     *
      * @return VariantInterface
      */
     public function getVariant()
@@ -49,6 +68,8 @@ class ParticipationEvent
     }
 
     /**
+     * Checks weather the participation of the user is new
+     *
      * @return boolean
      */
     public function isNew()

--- a/src/Event/ParticipationEvent.php
+++ b/src/Event/ParticipationEvent.php
@@ -6,8 +6,6 @@ use PhpAb\Test\TestInterface;
 use PhpAb\Variant\VariantInterface;
 
 /**
- * Class ParticipationEvent
- *
  * Holds information about a participation event which is needed for
  * further processing.
  */

--- a/src/Event/ParticipationEvent.php
+++ b/src/Event/ParticipationEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace PhpAb\Event;
+
+use PhpAb\Test\TestInterface;
+use PhpAb\Variant\VariantInterface;
+
+class ParticipationEvent
+{
+
+    const PARTICIPATION = 'phpab.participation';
+
+    /**
+     * @var \PhpAb\Test\TestInterface
+     */
+    private $test;
+
+    /**
+     * @var \PhpAb\Variant\VariantInterface
+     */
+    private $variant;
+
+    /**
+     * @var boolean
+     */
+    private $isNew;
+
+    public function __construct(TestInterface $test, VariantInterface $variant, $isNew)
+    {
+        $this->test = $test;
+        $this->variant = $variant;
+        $this->isNew = $isNew;
+    }
+
+    /**
+     * @return TestInterface
+     */
+    public function getTest()
+    {
+        return $this->test;
+    }
+
+    /**
+     * @return VariantInterface
+     */
+    public function getVariant()
+    {
+        return $this->variant;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isNew()
+    {
+        return $this->isNew;
+    }
+}

--- a/src/Event/SubscriberInterface.php
+++ b/src/Event/SubscriberInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Event;
+namespace PhpAb\Event;
 
-interface EventSubscriberInterface
+interface SubscriberInterface
 {
     public function getSubscribedEvents();
 }

--- a/src/Event/SubscriberInterface.php
+++ b/src/Event/SubscriberInterface.php
@@ -2,6 +2,11 @@
 
 namespace PhpAb\Event;
 
+/**
+ * Interface SubscriberInterface
+ *
+ * The Subscriber can listen to multiple events at once.
+ */
 interface SubscriberInterface
 {
     public function getSubscribedEvents();

--- a/src/Event/SubscriberInterface.php
+++ b/src/Event/SubscriberInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Event;
+
+interface EventSubscriberInterface
+{
+    public function getSubscribedEvents();
+}

--- a/src/Event/SubscriberInterface.php
+++ b/src/Event/SubscriberInterface.php
@@ -3,8 +3,6 @@
 namespace PhpAb\Event;
 
 /**
- * Interface SubscriberInterface
- *
  * The Subscriber can listen to multiple events at once.
  */
 interface SubscriberInterface

--- a/src/Storage/Session.php
+++ b/src/Storage/Session.php
@@ -19,7 +19,6 @@ class Session implements StorageInterface
      * Initializes a new instance of this class.
      *
      * @param string $namespace The namespace of the session.
-     * @param bool $startSession Whether or not to start the session if it hasn't been started yet.
      */
     public function __construct($namespace)
     {

--- a/tests/Event/DispatcherTest.php
+++ b/tests/Event/DispatcherTest.php
@@ -24,6 +24,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher = new Dispatcher();
         $dispatcher->addListener('event.foo', function ($subject) {
             $subject->executed = true;
+            return 'yolo';
         });
 
         $subject = new \stdClass();
@@ -58,10 +59,9 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $subject->touched = 0;
 
         // Act
-        $result = $dispatcher->dispatch('event.foo', $subject);
+        $dispatcher->dispatch('event.foo', $subject);
 
         // Assert
-        $this->assertNull($result);
         $this->assertEquals(1, $subject->touched);
     }
 
@@ -81,10 +81,9 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $subject->touched = 0;
 
         // Act
-        $result = $dispatcher->dispatch('event.foo', $subject);
+        $dispatcher->dispatch('event.foo', $subject);
 
         // Assert
-        $this->assertNull($result);
         $this->assertEquals(2, $subject->touched);
     }
 

--- a/tests/Event/DispatcherTest.php
+++ b/tests/Event/DispatcherTest.php
@@ -22,7 +22,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     {
         // Arrange
         $dispatcher = new Dispatcher();
-        $dispatcher->addListener('event.foo', function($subject) {
+        $dispatcher->addListener('event.foo', function ($subject) {
             $subject->executed = true;
         });
 
@@ -36,15 +36,44 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($subject->executed);
     }
 
+    public function testDispatchSubscriberNotAllDispatched()
+    {
+        // Arrange
+        $callable = function ($subject) {
+            $subject->touched++;
+        };
+
+        $subscriber = $this->getMock(SubscriberInterface::class);
+        $subscriber
+            ->method('getSubscribedEvents')
+            ->willReturn([
+                'event.foo' => $callable,
+                'event.bar' => $callable,
+            ]);
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->addSubscriber($subscriber);
+
+        $subject = new \stdClass();
+        $subject->touched = 0;
+
+        // Act
+        $result = $dispatcher->dispatch('event.foo', $subject);
+
+        // Assert
+        $this->assertNull($result);
+        $this->assertEquals(1, $subject->touched);
+    }
+
     public function testDispatchWithMultipleListenersOnOneEvent()
     {
         // Arrange
         $dispatcher = new Dispatcher();
-        $dispatcher->addListener('event.foo', function($subject) {
+        $dispatcher->addListener('event.foo', function ($subject) {
             $subject->touched++;
         });
 
-        $dispatcher->addListener('event.foo', function($subject) {
+        $dispatcher->addListener('event.foo', function ($subject) {
             $subject->touched++;
         });
 
@@ -63,11 +92,11 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     {
         // Arrange
         $dispatcher = new Dispatcher();
-        $dispatcher->addListener('event.foo', function($subject) {
+        $dispatcher->addListener('event.foo', function ($subject) {
             $subject->touched++;
         });
 
-        $dispatcher->addListener('event.bar', function($subject) {
+        $dispatcher->addListener('event.bar', function ($subject) {
             $subject->touched++;
         });
 

--- a/tests/Event/DispatcherTest.php
+++ b/tests/Event/DispatcherTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Event;
-
-use PhpAb\Event\Dispatcher;
+namespace PhpAb\Event;
 
 class DispatcherTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Event/DispatcherTest.php
+++ b/tests/Event/DispatcherTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Event;
+
+use PhpAb\Event\Dispatcher;
+
+class DispatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDispatchEventWithoutListeners()
+    {
+        // Arrange
+        $dispatcher = new Dispatcher();
+
+        // Act
+        $result1 = $dispatcher->dispatch('event', null);
+        $result2 = $dispatcher->dispatch('event2', null);
+
+        // Assert
+        $this->assertNull($result1);
+        $this->assertNull($result2);
+    }
+
+    public function testDispatchWithSingleListener()
+    {
+        // Arrange
+        $dispatcher = new Dispatcher();
+        $dispatcher->addListener('event.foo', function($subject) {
+            $subject->executed = true;
+        });
+
+        $subject = new \stdClass();
+
+        // Act
+        $result = $dispatcher->dispatch('event.foo', $subject);
+
+        // Assert
+        $this->assertNull($result);
+        $this->assertTrue($subject->executed);
+    }
+
+    public function testDispatchWithMultipleListenersOnOneEvent()
+    {
+        // Arrange
+        $dispatcher = new Dispatcher();
+        $dispatcher->addListener('event.foo', function($subject) {
+            $subject->touched++;
+        });
+
+        $dispatcher->addListener('event.foo', function($subject) {
+            $subject->touched++;
+        });
+
+        $subject = new \stdClass();
+        $subject->touched = 0;
+
+        // Act
+        $result = $dispatcher->dispatch('event.foo', $subject);
+
+        // Assert
+        $this->assertNull($result);
+        $this->assertEquals(2, $subject->touched);
+    }
+
+    public function testDispatchMultipleEvents()
+    {
+        // Arrange
+        $dispatcher = new Dispatcher();
+        $dispatcher->addListener('event.foo', function($subject) {
+            $subject->touched++;
+        });
+
+        $dispatcher->addListener('event.bar', function($subject) {
+            $subject->touched++;
+        });
+
+        $subject = new \stdClass();
+        $subject->touched = 0;
+
+        // Act
+        $dispatcher->dispatch('event.foo', $subject);
+        $dispatcher->dispatch('event.bar', $subject);
+
+        // Assert
+        $this->assertEquals(2, $subject->touched);
+    }
+}

--- a/tests/Event/ParticipationEventTest.php
+++ b/tests/Event/ParticipationEventTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PhpAb\Event;
+
+use PhpAb\Test\TestInterface;
+use PhpAb\Variant\VariantInterface;
+
+class ParticipationEventTest extends \PHPUnit_Framework_TestCase
+{
+    private $test;
+    private $variant;
+
+    public function setUp()
+    {
+        $this->test = $this->getMock(TestInterface::class);
+        $this->variant = $this->getMock(VariantInterface::class);
+    }
+
+    public function testGetTest()
+    {
+        // Arrange
+        $event = new ParticipationEvent($this->test, $this->variant, false);
+
+        // Act
+        $result = $event->getTest();
+
+        // Assert
+        $this->assertSame($this->test, $result);
+    }
+
+    public function testGetVariant()
+    {
+        // Arrange
+        $event = new ParticipationEvent($this->test, $this->variant, false);
+
+        // Act
+        $result = $event->getVariant();
+
+        // Assert
+        $this->assertSame($this->variant, $result);
+    }
+
+    public function testIsNotNew()
+    {
+        // Arrange
+        $event = new ParticipationEvent($this->test, $this->variant, false);
+
+        // Act
+        $result = $event->isNew();
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function testIsNew()
+    {
+        // Arrange
+        $event = new ParticipationEvent($this->test, $this->variant, true);
+
+        // Act
+        $result = $event->isNew();
+
+        // Assert
+        $this->assertTrue($result);
+    }
+}

--- a/tests/Variant/CallbackVariantTest.php
+++ b/tests/Variant/CallbackVariantTest.php
@@ -9,7 +9,8 @@ class CallbackVariantTest extends \PHPUnit_Framework_TestCase
     public function testGetIdentifier()
     {
         // Arrange
-        $variant = new CallbackVariant('name', function () {});
+        $variant = new CallbackVariant('name', function () {
+        });
 
         // Act
         $identifier = $variant->getIdentifier();


### PR DESCRIPTION
Relates to https://github.com/phpab/phpab/pull/44

I built in a (very simple) event system.
There is only one Interface needed: `DispatcherInterface` and i have one implementation ready.

I's the most simple EventSystem i can think of.
No Priorization or anything else.

Test Coverage is still 100%. Travis is still failing on 5.5 (and i don't know why, hope it will get away once merged).

**Please Review**

**If everything is fine we could start with the following tasks**

---
### Implement Engine

how should we depend on the EventDispatcher. Maybe force a private method `EngineInterface`?
### Implement other Event Systems
- Symfony
- Zend
- Laravel
- ThePhpLeague

i would do this directly in in a `Bridge/` folder and add them to suggest.
This is not required for a first release.
