### PR TITLE
Fix participation from previous runs

### DIFF
--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -153,7 +153,7 @@ class Engine implements EngineInterface
         // Let's try to recover a previously stored Variant
         if ($testParticipation) {
             $variant = $bag->getTest()->getVariant($testParticipation);
-            // If we managed to identifier a Variant by a previously stored
+            // If we managed to identify a Variant by a previously stored
             // participation, do its magic again
             if ($variant instanceof Variant\VariantInterface) {
                 $this->dispatcher->dispatch('phpab.participation.variant_run', [$this, $bag, $variant]);

--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -143,7 +143,7 @@ class Engine implements EngineInterface
                 // The user should not participate so let's set participation
                 // to null so he will not participate in the future, too.
                 $this->dispatcher->dispatch('phpab.participation.block', [$this, $bag]);
-                
+
                 $this->participationManager->participate($test->getIdentifier(), null);
 
                 return false;
@@ -156,7 +156,7 @@ class Engine implements EngineInterface
             // If we managed to identifier a Variant by a previously stored
             // participation, do its magic again
             if ($variant instanceof Variant\VariantInterface) {
-                $this->dispatcher->dispatch('phpab.participation.variant_run', [$variant]);
+                $this->dispatcher->dispatch('phpab.participation.variant_run', [$this, $bag, $variant]);
                 $variant->run();
 
                 return true;


### PR DESCRIPTION
This fixes participation when persistent storage was used for previous runs.
