### PR TITLE
Test closure in DB DataCollector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -17,7 +16,6 @@ matrix:
       env: 'UPLOAD_COVERAGE=true'
   fast_finish: true
   allow_failures:
-    - php: 5.4
     - php: hhvm
 
 before_install:

--- a/src/Analytics/DB/DataCollector.php
+++ b/src/Analytics/DB/DataCollector.php
@@ -32,7 +32,29 @@ class DataCollector implements SubscriberInterface
     public function getSubscribedEvents()
     {
         return [
-            'phpab.participation.variant_run' => function ($options) {
+            'phpab.participation.variant_run' => function (array $options) {
+
+                Assert::notEmpty($options, 'Array passed to closure cannot be empty.');
+
+                Assert::keyExists($options, 1, 'Second parameter passed to closure must be instance of Bag.');
+
+                Assert::isInstanceOf(
+                    $options[1],
+                    'PhpAb\Test\Bag',
+                    'Second parameter passed to closure must be instance of Bag.'
+                );
+
+                Assert::keyExists(
+                    $options,
+                    2,
+                    'Third parameter passed to closure must be instance of VariantInterface.'
+                );
+
+                Assert::isInstanceOf(
+                    $options[2],
+                    'PhpAb\Variant\VariantInterface',
+                    'Third parameter passed to closure must be instance of VariantInterface.'
+                );
 
                 /** @var TestInterface $test */
                 $test = $options[1]->getTest();

--- a/tests/Analytics/DataCollector/GenericTest.php
+++ b/tests/Analytics/DataCollector/GenericTest.php
@@ -18,6 +18,10 @@ use PHPUnit_Framework_TestCase;
 
 class GenericTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * Testing that getSubscribedEventst will return an array
+     * containing the closure to be executed on "phpab.participation.variant_run"
+     */
     public function testGetSubscribedEvents()
     {
         // Arrange
@@ -32,9 +36,11 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that addParticipation accepts only string parameters
+     *
      * @expectedException InvalidArgumentException
      */
-    public function addParticipationInvalidTestIdentifier()
+    public function testAddParticipationInvalidTestIdentifier()
     {
         // Arrange
         $collector = new Generic();
@@ -46,29 +52,17 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that addParticipation accepts only string parameters
+     *
      * @expectedException InvalidArgumentException
      */
-    public function addParticipationInvalidVariationIndexRange()
+    public function testAddParticipationInvalidVariationIndexRange()
     {
         // Arrange
         $collector = new Generic();
 
         // Act
         $collector->addParticipation('walter', -1);
-
-        // Assert
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function addParticipationInvalidVariationNotInt()
-    {
-        // Arrange
-        $collector = new Generic();
-
-        // Act
-        $collector->addParticipation('walter', '1');
 
         // Assert
     }

--- a/tests/Analytics/DataCollector/GenericTest.php
+++ b/tests/Analytics/DataCollector/GenericTest.php
@@ -19,7 +19,7 @@ use PHPUnit_Framework_TestCase;
 class GenericTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Testing that getSubscribedEventst will return an array
+     * Testing that getSubscribedEvents() will return an array
      * containing the closure to be executed on "phpab.participation.variant_run"
      */
     public function testGetSubscribedEvents()
@@ -36,7 +36,7 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Testing that addParticipation accepts only string parameters
+     * Testing that addParticipation() accepts only string parameters
      *
      * @expectedException InvalidArgumentException
      */
@@ -52,7 +52,7 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Testing that addParticipation accepts only string parameters
+     * Testing that addParticipation() accepts only string parameters
      *
      * @expectedException InvalidArgumentException
      */
@@ -67,6 +67,10 @@ class GenericTest extends PHPUnit_Framework_TestCase
         // Assert
     }
 
+    /**
+     * Testing that getTestsData() returns the data injected
+     * via addParticipation()
+     */
     public function testOnRegisterParticipation()
     {
         // Arrange
@@ -88,6 +92,9 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * requires a non empty array
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testGetSubscribedEventsEmptyOptions()
@@ -103,6 +110,9 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * requires an array with size > 1
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testGetSubscribedEventsNoBag()
@@ -123,6 +133,9 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * requires a Bag object passed in key 1
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testGetSubscribedEventsNoBagInstance()
@@ -144,6 +157,9 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * requires an array with size > 2
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testGetSubscribedEventsNoVariant()
@@ -170,6 +186,10 @@ class GenericTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * requires an array with an instance of VariantInterface
+     * in key 2
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testGetSubscribedEventsNoVariantInstance()
@@ -196,6 +216,10 @@ class GenericTest extends PHPUnit_Framework_TestCase
         // Assert
     }
 
+    /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * fills correctly the participation array
+     */
     public function testRunEvent()
     {
         // Arrange


### PR DESCRIPTION
As in https://github.com/phpab/phpab/issues/83, too much is happening inside DataCollectors without being tested nor having their inputs validated.
This is an attempt to fix that.
