### PR TITLE
Major rewrite of the participation manager.

### DIFF
--- a/src/Participation/Manager.php
+++ b/src/Participation/Manager.php
@@ -38,38 +38,54 @@ class Manager implements ManagerInterface
     }
 
     /**
+     * Gets the variant the user is participating in for the given test.
+     *
+     * @param TestInterface|string $test The identifier of the test to get the variant for.
+     * @return string|null Returns the identifier of the variant or null if not participating.
+     */
+    public function getParticipatingVariant($test)
+    {
+        $test = $test instanceof TestInterface ? $test->getIdentifier() : $test;
+
+        if ($this->storage->has($test)) {
+            return $this->storage->get($test);
+        }
+
+        return null;
+    }
+
+    /**
      * {@inheritDoc}
      *
-     * @param string $test The identifier of the test to check.
-     * @param string|null $variant The identifier of the variant to check
+     * @param TestInterface|string $test The identifier of the test to check.
+     * @param VariantInterface|string|null $variant The identifier of the variant to check
+     * @return boolean|string Returns true when the user participates; false otherwise.
      */
     public function participates($test, $variant = null)
     {
         $test = $test instanceof TestInterface ? $test->getIdentifier() : $test;
         $variant = $variant instanceof VariantInterface ? $variant->getIdentifier() : $variant;
 
+        if (!$this->storage->has($test)) {
+            return false;
+        }
+
         $storedValue = $this->storage->get($test);
 
-        if (null !== $variant && $storedValue === $variant) {
-            // It was asked explicitly for the variant and it matches
-            return true;
+        // It was asked explicitly for the variant and it matches
+        if (null !== $variant) {
+            return $storedValue === $variant;
         }
 
-        if (null === $variant && $this->storage->has($test)) {
-            // The stored value exists, so we participate at the test
-            // lets return the stored variant
-            return $storedValue;
-        }
-
-        return false;
+        return true;
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param string $test The identifier of the test that should be participated.
-     * @param string|false $variant The identifier of the variant that was chosen for the user
-     * or false if the user should not participate at the test.
+     * @param TestInterface|string $test The identifier of the test that should be participated.
+     * @param VariantInterface|string|null $variant The identifier of the variant that was chosen or
+     * null if the user does not participate in the test.
      */
     public function participate($test, $variant)
     {

--- a/src/Participation/ManagerInterface.php
+++ b/src/Participation/ManagerInterface.php
@@ -17,23 +17,28 @@ namespace PhpAb\Participation;
 interface ManagerInterface
 {
     /**
-     * Check if the User participates in a test or a specific variant of the test
+     * Gets the variant the user is participating in for the given test.
      *
-     * @param string $test The identifier of the test to check.
-     * @param string|null $variant The identifier of the variant to check
+     * @param TestInterface|string $test The identifier of the test to get the variant for.
+     * @return string|null Returns the identifier of the variant or null if not participating.
+     */
+    public function getParticipatingVariant($test);
+
+    /**
+     * Check if the user participates in a test or a specific variant of the test
      *
-     * @return boolean|string Returns false if there is no participation.
-     * Returns a string for the participated variant if participating.
-     * Returns true if explicit variant was asked and matches
+     * @param TestInterface|string $test The identifier of the test to check.
+     * @param VariantInterface|string|null $variant The identifier of the variant to check
+     * @return boolean|string Returns true when the user participates; false otherwise.
      */
     public function participates($test, $variant = null);
 
     /**
      * Sets the participation to a test with the participation at a specific variant.
      *
-     * @param string $test The identifier of the test that should be participated.
-     * @param string|false $variant The identifier of the variant that was chosen for the user
-     * or false if the user should not participate at the test.
+     * @param TestInterface|string $test The identifier of the test that should be participated.
+     * @param VariantInterface|string|null $variant The identifier of the variant that was chosen or
+     * null if the user does not participate in the test.
      */
     public function participate($test, $variant);
 }

--- a/tests/Engine/EngineTest.php
+++ b/tests/Engine/EngineTest.php
@@ -110,6 +110,10 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         // Arrange
         $this->manager->method('participates')
             ->with('foo')
+            ->willReturn(true);
+
+        $this->manager->method('getParticipatingVariant')
+            ->with('foo')
             ->willReturn('bar');
 
         $this->variant
@@ -137,7 +141,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         // Arrange
         $this->manager->method('participates')
             ->with('foo')
-            ->willReturn('bar');
+            ->willReturn(false);
 
         $this->variant
             ->expects($this->exactly(0))
@@ -194,7 +198,8 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         $result = $manager->participates('foo');
 
         // Assert
-        $this->assertNull($result);
+        $this->assertTrue($result);
+        $this->assertNull($manager->getParticipatingVariant('foo'));
     }
 
     public function testUserShouldNotParticipate()
@@ -211,7 +216,8 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         $result = $manager->participates('foo');
 
         // Assert
-        $this->assertNull($result);
+        $this->assertTrue($result);
+        $this->assertNull($manager->getParticipatingVariant('foo'));
     }
 
     public function testUserShouldNotParticipateWithExistingVariant()
@@ -231,7 +237,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         $result = $manager->participates('foo');
 
         // Assert
-        $this->assertNull($result);
+        $this->assertTrue($result);
     }
 
     public function testUserGetsNewParticipation()
@@ -253,7 +259,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         $result = $manager->participates('t1');
 
         // Assert
-        $this->assertEquals('v1', $result);
+        $this->assertTrue($result);
     }
 
     public function testNoVariantAvailableForTest()
@@ -271,7 +277,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         $result = $manager->participates('t1');
 
         // Assert
-        $this->assertNull($result);
+        $this->assertTrue($result);
     }
 
     /**
@@ -341,7 +347,6 @@ class EngineTest extends \PHPUnit_Framework_TestCase
             ],
             $testData
         );
-
     }
 
     /**

--- a/tests/Participation/ManagerTest.php
+++ b/tests/Participation/ManagerTest.php
@@ -45,7 +45,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
         $result = $manager->participates('foo');
 
         // Assert
-        $this->assertEquals('bar', $result);
+        $this->assertTrue($result);
     }
 
     public function testCheckParticipatesTestObjectSuccess()
@@ -58,7 +58,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
         $result = $manager->participates('foo');
 
         // Assert
-        $this->assertNull($result);
+        $this->assertTrue($result);
     }
 
     public function testCheckParticipatesTestVariantObjectSuccess()


### PR DESCRIPTION
This PR fixes issue #87 .

Biggest change is that the `participates` method no longer returns the identifier of the variant. Instead it will only return true or false. True when the user is participating (even if the chosen variant is null) and false otherwise.

To get the variant for the test, use the `getParticipatingVariant` method which is introduced in this PR.
