### PR TITLE
:bulb: Pass Google Analytics Experiment ID as an option to Test to keep test identifiers readable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "Mariano F.co Benítez Mulet",
-            "email": "nanodevel@gmail.com",
+            "email": "pachicodev@gmail.com",
             "homepage": "https://github.com/pachico",
             "role": "Developer"
         }
@@ -56,6 +56,8 @@
         "symfony/event-dispatcher": "^3.0"
     },
     "suggest": {
-        "symfony/event-dispatcher": "Allows to use the (way better) symfony EventDispatcher with the packages eventsystem."
+        "symfony/event-dispatcher": "Allows to use the (way better) symfony EventDispatcher with the packages eventsystem.",
+        "phpab/analytics-mongodb": "Allows to save test participation in MongoDB.",
+        "phpab/analytics-pdo": "Allows to save test participation using PDO DBAL."
     }
 }

--- a/src/Analytics/DataCollector/Google.php
+++ b/src/Analytics/DataCollector/Google.php
@@ -13,7 +13,6 @@ use PhpAb\Event\SubscriberInterface;
 use PhpAb\Test\TestInterface;
 use PhpAb\Variant\VariantInterface;
 use Webmozart\Assert\Assert;
-use PhpAb\Test\Bag;
 
 /**
  * A data collector that holds information about which tests have been executed in a format for Google.
@@ -22,7 +21,7 @@ use PhpAb\Test\Bag;
  */
 class Google implements SubscriberInterface
 {
-    const EXPERIMENT_ID = 'GAExperimentId';
+    const EXPERIMENT_ID = 'experimentId';
 
     /**
      * @var array Test identifiers and variation indexes
@@ -58,19 +57,16 @@ class Google implements SubscriberInterface
                     'Third parameter passed to closure must be instance of VariantInterface.'
                 );
 
-                /** @var Bag $bag */
-                $bag = $options[1];
-
                 /** @var TestInterface $test */
-                $test = $bag->getTest();
+                $test = $options[1]->getTest();
 
                 Assert::keyExists(
-                    $bag->getOptions(),
+                    $test->getOptions(),
                     static::EXPERIMENT_ID,
                     'A Google Analytics Experiment Id must be set as options.'
                 );
 
-                $experimentId = $bag->getOptions()[static::EXPERIMENT_ID];
+                $experimentId = $test->getOptions()[static::EXPERIMENT_ID];
 
                 /** @var VariantInterface $chosenVariant */
                 $chosenVariant = $options[2];

--- a/src/Analytics/DataCollector/Google.php
+++ b/src/Analytics/DataCollector/Google.php
@@ -13,6 +13,7 @@ use PhpAb\Event\SubscriberInterface;
 use PhpAb\Test\TestInterface;
 use PhpAb\Variant\VariantInterface;
 use Webmozart\Assert\Assert;
+use PhpAb\Test\Bag;
 
 /**
  * A data collector that holds information about which tests have been executed in a format for Google.
@@ -21,7 +22,7 @@ use Webmozart\Assert\Assert;
  */
 class Google implements SubscriberInterface
 {
-    const EXPERIMENT_ID = 'experimentId';
+    const EXPERIMENT_ID = 'GAExperimentId';
 
     /**
      * @var array Test identifiers and variation indexes
@@ -57,16 +58,19 @@ class Google implements SubscriberInterface
                     'Third parameter passed to closure must be instance of VariantInterface.'
                 );
 
+                /** @var Bag $bag */
+                $bag = $options[1];
+
                 /** @var TestInterface $test */
-                $test = $options[1]->getTest();
+                $test = $bag->getTest();
 
                 Assert::keyExists(
-                    $test->getOptions(),
+                    $bag->getOptions(),
                     static::EXPERIMENT_ID,
-                    'A Ggoogle Analytics Experiment Id must be set as options.'
+                    'A Google Analytics Experiment Id must be set as options.'
                 );
 
-                $experimentId = $test->getOptions()[static::EXPERIMENT_ID];
+                $experimentId = $bag->getOptions()[static::EXPERIMENT_ID];
 
                 /** @var VariantInterface $chosenVariant */
                 $chosenVariant = $options[2];

--- a/src/Analytics/DataCollector/Google.php
+++ b/src/Analytics/DataCollector/Google.php
@@ -21,6 +21,8 @@ use Webmozart\Assert\Assert;
  */
 class Google implements SubscriberInterface
 {
+    const EXPERIMENT_ID = 'experimentId';
+
     /**
      * @var array Test identifiers and variation indexes
      */
@@ -58,6 +60,14 @@ class Google implements SubscriberInterface
                 /** @var TestInterface $test */
                 $test = $options[1]->getTest();
 
+                Assert::keyExists(
+                    $test->getOptions(),
+                    static::EXPERIMENT_ID,
+                    'A Ggoogle Analytics Experiment Id must be set as options.'
+                );
+
+                $experimentId = $test->getOptions()[static::EXPERIMENT_ID];
+
                 /** @var VariantInterface $chosenVariant */
                 $chosenVariant = $options[2];
 
@@ -67,7 +77,7 @@ class Google implements SubscriberInterface
                 $chosenIndex = array_search($chosenVariant->getIdentifier(), array_keys($variants));
 
                 // Call the add method
-                $this->addParticipation($test->getIdentifier(), $chosenIndex);
+                $this->addParticipation($experimentId, $chosenIndex);
             }
         ];
     }

--- a/src/Analytics/Renderer/Google/AbstractGoogleAnalytics.php
+++ b/src/Analytics/Renderer/Google/AbstractGoogleAnalytics.php
@@ -25,6 +25,11 @@ abstract class AbstractGoogleAnalytics implements JavascriptRendererInterface
     private $includeApiClient = false;
 
     /**
+     * @var bool Wheter or not to fire an event after Experiments are set
+     */
+    private $includeEventTrigger = true;
+
+    /**
      * @param bool $includeApiClient Whether or not to include the Api Client
      */
     public function setApiClientInclusion($includeApiClient = false)
@@ -38,5 +43,21 @@ abstract class AbstractGoogleAnalytics implements JavascriptRendererInterface
     public function getApiClientInclusion()
     {
         return $this->includeApiClient;
+    }
+
+    /**
+     * @param bool $includeEventTrigger Wheter or not to fire an event after Experiments are set
+     */
+    public function setEventTriggerInclusion($includeEventTrigger = true)
+    {
+        $this->includeEventTrigger = true === $includeEventTrigger;
+    }
+
+    /**
+     * @return bool the value of $includeEventTrigger
+     */
+    public function getEventTriggerInclusion()
+    {
+        return $this->includeEventTrigger;
     }
 }

--- a/src/Analytics/Renderer/Google/AbstractGoogleAnalytics.php
+++ b/src/Analytics/Renderer/Google/AbstractGoogleAnalytics.php
@@ -27,7 +27,7 @@ abstract class AbstractGoogleAnalytics implements JavascriptRendererInterface
     /**
      * @param bool $includeApiClient Whether or not to include the Api Client
      */
-    public function setApiCLientInclusion($includeApiClient = false)
+    public function setApiClientInclusion($includeApiClient = false)
     {
         $this->includeApiClient = true === $includeApiClient;
     }
@@ -35,7 +35,7 @@ abstract class AbstractGoogleAnalytics implements JavascriptRendererInterface
     /**
      * @return bool The value of $includeApiClient
      */
-    public function getApiCLientInclusion()
+    public function getApiClientInclusion()
     {
         return $this->includeApiClient;
     }

--- a/src/Analytics/Renderer/Google/AbstractGoogleAnalytics.php
+++ b/src/Analytics/Renderer/Google/AbstractGoogleAnalytics.php
@@ -25,11 +25,6 @@ abstract class AbstractGoogleAnalytics implements JavascriptRendererInterface
     private $includeApiClient = false;
 
     /**
-     * @var bool Wheter or not to fire an event after Experiments are set
-     */
-    private $includeEventTrigger = true;
-
-    /**
      * @param bool $includeApiClient Whether or not to include the Api Client
      */
     public function setApiClientInclusion($includeApiClient = false)
@@ -43,21 +38,5 @@ abstract class AbstractGoogleAnalytics implements JavascriptRendererInterface
     public function getApiClientInclusion()
     {
         return $this->includeApiClient;
-    }
-
-    /**
-     * @param bool $includeEventTrigger Wheter or not to fire an event after Experiments are set
-     */
-    public function setEventTriggerInclusion($includeEventTrigger = true)
-    {
-        $this->includeEventTrigger = true === $includeEventTrigger;
-    }
-
-    /**
-     * @return bool the value of $includeEventTrigger
-     */
-    public function getEventTriggerInclusion()
-    {
-        return $this->includeEventTrigger;
     }
 }

--- a/src/Analytics/Renderer/Google/GoogleClassicAnalytics.php
+++ b/src/Analytics/Renderer/Google/GoogleClassicAnalytics.php
@@ -52,8 +52,12 @@ class GoogleClassicAnalytics extends AbstractGoogleAnalytics
         $script[] = '<script>';
 
         foreach ($this->participations as $testIdentifier => $variationIndex) {
-            $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');";
-            $script[] = "_gaq.push(['_trackEvent', 'PhpAb', 'testRun', '" . (string) $testIdentifier . "', 1]);";
+            $script[] = "(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');
+        _gaq.push(['_trackEvent', 'PhpAb', 'testRun', '" . (string) $testIdentifier . "', 1]);
+    });
+})();";
         }
 
         $script[] = '</script>';

--- a/src/Analytics/Renderer/Google/GoogleClassicAnalytics.php
+++ b/src/Analytics/Renderer/Google/GoogleClassicAnalytics.php
@@ -52,7 +52,12 @@ class GoogleClassicAnalytics extends AbstractGoogleAnalytics
         $script[] = '<script>';
 
         foreach ($this->participations as $testIdentifier => $variationIndex) {
-            $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "')";
+            $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');";
+        }
+
+        if (true === $this->getEventTriggerInclusion()) {
+            $script[] = "_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', "
+                . count($this->participations) . "]);";
         }
 
         $script[] = '</script>';

--- a/src/Analytics/Renderer/Google/GoogleClassicAnalytics.php
+++ b/src/Analytics/Renderer/Google/GoogleClassicAnalytics.php
@@ -53,11 +53,7 @@ class GoogleClassicAnalytics extends AbstractGoogleAnalytics
 
         foreach ($this->participations as $testIdentifier => $variationIndex) {
             $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');";
-        }
-
-        if (true === $this->getEventTriggerInclusion()) {
-            $script[] = "_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', "
-                . count($this->participations) . "]);";
+            $script[] = "_gaq.push(['_trackEvent', 'PhpAb', 'testRun', '" . (string) $testIdentifier . "', 1]);";
         }
 
         $script[] = '</script>';

--- a/src/Analytics/Renderer/Google/GoogleUniversalAnalytics.php
+++ b/src/Analytics/Renderer/Google/GoogleUniversalAnalytics.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of phpab/phpab. (https://github.com/phpab/phpab)
  *
@@ -53,10 +54,7 @@ class GoogleUniversalAnalytics extends AbstractGoogleAnalytics
 
         foreach ($this->participations as $testIdentifier => $variationIndex) {
             $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');";
-        }
-
-        if (true === $this->getEventTriggerInclusion()) {
-            $script[] = "ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', " . count($this->participations) . ");";
+            $script[] = "ga('send', 'event', 'PhpAb', 'testRun', '" . (string) $testIdentifier . "', 1);";
         }
 
         $script[] = '</script>';

--- a/src/Analytics/Renderer/Google/GoogleUniversalAnalytics.php
+++ b/src/Analytics/Renderer/Google/GoogleUniversalAnalytics.php
@@ -52,7 +52,11 @@ class GoogleUniversalAnalytics extends AbstractGoogleAnalytics
         $script[] = '<script>';
 
         foreach ($this->participations as $testIdentifier => $variationIndex) {
-            $script[] = "ga('set', '" . (string) $testIdentifier . "', " . (int) $variationIndex . ");";
+            $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');";
+        }
+
+        if (true === $this->getEventTriggerInclusion()) {
+            $script[] = "ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', " . count($this->participations) . ");";
         }
 
         $script[] = '</script>';

--- a/src/Analytics/Renderer/Google/GoogleUniversalAnalytics.php
+++ b/src/Analytics/Renderer/Google/GoogleUniversalAnalytics.php
@@ -53,8 +53,12 @@ class GoogleUniversalAnalytics extends AbstractGoogleAnalytics
         $script[] = '<script>';
 
         foreach ($this->participations as $testIdentifier => $variationIndex) {
-            $script[] = "cxApi.setChosenVariation(" . (int) $variationIndex . ", '" . (string) $testIdentifier . "');";
-            $script[] = "ga('send', 'event', 'PhpAb', 'testRun', '" . (string) $testIdentifier . "', 1);";
+            $script[] = "(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(".$variationIndex.", '".$testIdentifier."');
+        tracker.send('event', 'PhpAb', '".$testIdentifier."', {'nonInteraction': 1});
+    });
+})();";
         }
 
         $script[] = '</script>';

--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -150,7 +150,12 @@ class Engine implements EngineInterface
         Assert::notNull($filter, 'There must be at least one filter in the Engine or in the TestBag');
         Assert::notNull($chooser, 'There must be at least one chooser in the Engine or in the TestBag');
 
-        $this->tests[$test->getIdentifier()] = new Bag($test, $filter, $chooser, $options);
+        $this->tests[$test->getIdentifier()] = new Bag(
+            $test,
+            $filter,
+            $chooser,
+            array_merge($options, $test->getOptions())
+        );
     }
 
     /**

--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -150,12 +150,7 @@ class Engine implements EngineInterface
         Assert::notNull($filter, 'There must be at least one filter in the Engine or in the TestBag');
         Assert::notNull($chooser, 'There must be at least one chooser in the Engine or in the TestBag');
 
-        $this->tests[$test->getIdentifier()] = new Bag(
-            $test,
-            $filter,
-            $chooser,
-            array_merge($options, $test->getOptions())
-        );
+        $this->tests[$test->getIdentifier()] = new Bag($test, $filter, $chooser, $options);
     }
 
     /**

--- a/src/Test/Test.php
+++ b/src/Test/Test.php
@@ -35,12 +35,20 @@ class Test implements TestInterface
     private $variants;
 
     /**
+     * Case specific options
+     *
+     * @var array
+     */
+    private $options = [];
+
+    /**
      * Initializes a new instance of this class.
      *
      * @param string $identifier The identifier
      * @param VariantInterface[] $variants The variants that this test has.
+     * @param array $options Case specific test options.
      */
-    public function __construct($identifier, $variants = [])
+    public function __construct($identifier, $variants = [], array $options = [])
     {
         if (!is_string($identifier) || $identifier === '') {
             throw new InvalidArgumentException('The provided identifier is not a valid identifier.');
@@ -48,6 +56,7 @@ class Test implements TestInterface
 
         $this->identifier = $identifier;
         $this->setVariants($variants);
+        $this->options = $options;
     }
 
     /**
@@ -108,5 +117,15 @@ class Test implements TestInterface
         }
 
         return $this->variants[$identifier];
+    }
+
+    /**
+     * Get the test options
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 }

--- a/tests/Analytics/DataCollector/GoogleTest.php
+++ b/tests/Analytics/DataCollector/GoogleTest.php
@@ -277,11 +277,11 @@ class GoogleTest extends PHPUnit_Framework_TestCase
         $bag = new Bag(
             new Test(
                 'Bernard',
-                [new SimpleVariant('Black')]
+                [new SimpleVariant('Black')],
+                [Google::EXPERIMENT_ID => 'EXPID']
             ),
             new Percentage(100),
-            new RandomChooser,
-            [Google::EXPERIMENT_ID => 'EXPID']
+            new RandomChooser
         );
 
         // Act

--- a/tests/Analytics/DataCollector/GoogleTest.php
+++ b/tests/Analytics/DataCollector/GoogleTest.php
@@ -185,7 +185,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
         $collector = new Google();
         $event = $collector->getSubscribedEvents();
         $bag = new Bag(
-            new Test('Bernard'),
+            new Test('Bernard', [], [Google::EXPERIMENT_ID => 'EXPID']),
             new Percentage(100),
             new RandomChooser
         );
@@ -215,7 +215,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
         $collector = new Google();
         $eventCallback = $collector->getSubscribedEvents();
         $bag = new Bag(
-            new Test('Bernard'),
+            new Test('Bernard', [], [Google::EXPERIMENT_ID => 'EXPID']),
             new Percentage(100),
             new RandomChooser
         );
@@ -227,6 +227,38 @@ class GoogleTest extends PHPUnit_Framework_TestCase
                 0 => 'foo',
                 1 => $bag,
                 2 => new \DateTime
+            ]
+        );
+
+        // Assert
+    }
+
+    /**
+     * Testing that the closure returned by getSubscribedEvents()
+     * requires an array with an instance of VariantInterface
+     * in key 2
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A Ggoogle Analytics Experiment Id must be set as options.
+     */
+    public function testGetSubscribedEventsNoTestOption()
+    {
+        // Arrange
+        $collector = new Google();
+        $eventCallback = $collector->getSubscribedEvents();
+        $bag = new Bag(
+            new Test('Bernard', []),
+            new Percentage(100),
+            new RandomChooser
+        );
+
+        // Act
+        call_user_func(
+            $eventCallback['phpab.participation.variant_run'],
+            [
+                0 => 'foo',
+                1 => $bag,
+                2 => new SimpleVariant('Black')
             ]
         );
 
@@ -247,7 +279,8 @@ class GoogleTest extends PHPUnit_Framework_TestCase
         $bag = new Bag(
             new Test(
                 'Bernard',
-                [new SimpleVariant('Black')]
+                [new SimpleVariant('Black')],
+                [Google::EXPERIMENT_ID => 'EXPID']
             ),
             new Percentage(100),
             new RandomChooser
@@ -267,7 +300,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertSame(
-            ['Bernard' => 0],
+            ['EXPID' => 0],
             $participations
         );
     }

--- a/tests/Analytics/DataCollector/GoogleTest.php
+++ b/tests/Analytics/DataCollector/GoogleTest.php
@@ -239,7 +239,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
      * in key 2
      *
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A Ggoogle Analytics Experiment Id must be set as options.
+     * @expectedExceptionMessage A Google Analytics Experiment Id must be set as options.
      */
     public function testGetSubscribedEventsNoTestOption()
     {
@@ -268,8 +268,6 @@ class GoogleTest extends PHPUnit_Framework_TestCase
     /**
      * Testing that the closure returned by getSubscribedEvents()
      * fills correctly the participation array
-     *
-     * @group testme
      */
     public function testRunEvent()
     {
@@ -279,11 +277,11 @@ class GoogleTest extends PHPUnit_Framework_TestCase
         $bag = new Bag(
             new Test(
                 'Bernard',
-                [new SimpleVariant('Black')],
-                [Google::EXPERIMENT_ID => 'EXPID']
+                [new SimpleVariant('Black')]
             ),
             new Percentage(100),
-            new RandomChooser
+            new RandomChooser,
+            [Google::EXPERIMENT_ID => 'EXPID']
         );
 
         // Act

--- a/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
@@ -27,8 +27,9 @@ class GoogleClassicAnalyticsTest extends PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertSame("<script>
-cxApi.setChosenVariation(1, 'walter')
-cxApi.setChosenVariation(0, 'bernard')
+cxApi.setChosenVariation(1, 'walter');
+cxApi.setChosenVariation(0, 'bernard');
+_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', 2]);
 </script>", $script);
     }
 
@@ -47,8 +48,30 @@ cxApi.setChosenVariation(0, 'bernard')
         // Assert
         $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
 <script>
-cxApi.setChosenVariation(1, 'walter')
-cxApi.setChosenVariation(0, 'bernard')
+cxApi.setChosenVariation(1, 'walter');
+cxApi.setChosenVariation(0, 'bernard');
+_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', 2]);
+</script>", $script);
+    }
+
+    public function testGetScriptWithApiClientWithoutEvent()
+    {
+        // Arrange
+        $gaRenderer = new GoogleClassicAnalytics([
+            'walter' => 1,
+            'bernard' => 0
+        ]);
+        $gaRenderer->setApiClientInclusion(true);
+        $gaRenderer->setEventTriggerInclusion(false);
+
+        // Act
+        $script = $gaRenderer->getScript(true);
+
+        // Assert
+        $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
+<script>
+cxApi.setChosenVariation(1, 'walter');
+cxApi.setChosenVariation(0, 'bernard');
 </script>", $script);
     }
 

--- a/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
@@ -28,8 +28,9 @@ class GoogleClassicAnalyticsTest extends PHPUnit_Framework_TestCase
         // Assert
         $this->assertSame("<script>
 cxApi.setChosenVariation(1, 'walter');
+_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'walter', 1]);
 cxApi.setChosenVariation(0, 'bernard');
-_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', 2]);
+_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
 </script>", $script);
     }
 
@@ -49,29 +50,9 @@ _gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', 2]);
         $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
 <script>
 cxApi.setChosenVariation(1, 'walter');
+_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'walter', 1]);
 cxApi.setChosenVariation(0, 'bernard');
-_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'testsAmout', 2]);
-</script>", $script);
-    }
-
-    public function testGetScriptWithApiClientWithoutEvent()
-    {
-        // Arrange
-        $gaRenderer = new GoogleClassicAnalytics([
-            'walter' => 1,
-            'bernard' => 0
-        ]);
-        $gaRenderer->setApiClientInclusion(true);
-        $gaRenderer->setEventTriggerInclusion(false);
-
-        // Act
-        $script = $gaRenderer->getScript(true);
-
-        // Assert
-        $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
-<script>
-cxApi.setChosenVariation(1, 'walter');
-cxApi.setChosenVariation(0, 'bernard');
+_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
 </script>", $script);
     }
 

--- a/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
@@ -39,7 +39,7 @@ cxApi.setChosenVariation(0, 'bernard')
             'walter' => 1,
             'bernard' => 0
         ]);
-        $gaRenderer->setApiCLientInclusion(true);
+        $gaRenderer->setApiClientInclusion(true);
 
         // Act
         $script = $gaRenderer->getScript(true);

--- a/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleClassicAnalyticsTest.php
@@ -27,10 +27,18 @@ class GoogleClassicAnalyticsTest extends PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertSame("<script>
-cxApi.setChosenVariation(1, 'walter');
-_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'walter', 1]);
-cxApi.setChosenVariation(0, 'bernard');
-_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(1, 'walter');
+        _gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'walter', 1]);
+    });
+})();
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(0, 'bernard');
+        _gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
+    });
+})();
 </script>", $script);
     }
 
@@ -49,10 +57,18 @@ _gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
         // Assert
         $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
 <script>
-cxApi.setChosenVariation(1, 'walter');
-_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'walter', 1]);
-cxApi.setChosenVariation(0, 'bernard');
-_gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(1, 'walter');
+        _gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'walter', 1]);
+    });
+})();
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(0, 'bernard');
+        _gaq.push(['_trackEvent', 'PhpAb', 'testRun', 'bernard', 1]);
+    });
+})();
 </script>", $script);
     }
 

--- a/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
@@ -27,8 +27,9 @@ class GoogleUniversalAnalyticsTest extends PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertSame("<script>
-ga('set', 'walter', 1);
-ga('set', 'bernard', 0);
+cxApi.setChosenVariation(1, 'walter');
+cxApi.setChosenVariation(0, 'bernard');
+ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', 2);
 </script>", $script);
     }
 
@@ -47,8 +48,30 @@ ga('set', 'bernard', 0);
         // Assert
         $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
 <script>
-ga('set', 'walter', 1);
-ga('set', 'bernard', 0);
+cxApi.setChosenVariation(1, 'walter');
+cxApi.setChosenVariation(0, 'bernard');
+ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', 2);
+</script>", $script);
+    }
+
+    public function testGetScriptWithApiClientWithoutEvent()
+    {
+        // Arrange
+        $gaRenderer = new GoogleUniversalAnalytics([
+            'walter' => 1,
+            'bernard' => 0
+        ]);
+        $gaRenderer->setApiClientInclusion(true);
+        $gaRenderer->setEventTriggerInclusion(false);
+
+        // Act
+        $script = $gaRenderer->getScript(true);
+
+        // Assert
+        $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
+<script>
+cxApi.setChosenVariation(1, 'walter');
+cxApi.setChosenVariation(0, 'bernard');
 </script>", $script);
     }
 

--- a/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
@@ -39,7 +39,7 @@ ga('set', 'bernard', 0);
             'walter' => 1,
             'bernard' => 0
         ]);
-        $gaRenderer->setApiCLientInclusion(true);
+        $gaRenderer->setApiClientInclusion(true);
 
         // Act
         $script = $gaRenderer->getScript(true);

--- a/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
@@ -28,8 +28,9 @@ class GoogleUniversalAnalyticsTest extends PHPUnit_Framework_TestCase
         // Assert
         $this->assertSame("<script>
 cxApi.setChosenVariation(1, 'walter');
+ga('send', 'event', 'PhpAb', 'testRun', 'walter', 1);
 cxApi.setChosenVariation(0, 'bernard');
-ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', 2);
+ga('send', 'event', 'PhpAb', 'testRun', 'bernard', 1);
 </script>", $script);
     }
 
@@ -49,29 +50,9 @@ ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', 2);
         $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
 <script>
 cxApi.setChosenVariation(1, 'walter');
+ga('send', 'event', 'PhpAb', 'testRun', 'walter', 1);
 cxApi.setChosenVariation(0, 'bernard');
-ga('send', 'event', 'PhpAb', 'testRun', 'testsAmout', 2);
-</script>", $script);
-    }
-
-    public function testGetScriptWithApiClientWithoutEvent()
-    {
-        // Arrange
-        $gaRenderer = new GoogleUniversalAnalytics([
-            'walter' => 1,
-            'bernard' => 0
-        ]);
-        $gaRenderer->setApiClientInclusion(true);
-        $gaRenderer->setEventTriggerInclusion(false);
-
-        // Act
-        $script = $gaRenderer->getScript(true);
-
-        // Assert
-        $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
-<script>
-cxApi.setChosenVariation(1, 'walter');
-cxApi.setChosenVariation(0, 'bernard');
+ga('send', 'event', 'PhpAb', 'testRun', 'bernard', 1);
 </script>", $script);
     }
 

--- a/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
+++ b/tests/Analytics/Renderer/Google/GoogleUniversalAnalyticsTest.php
@@ -27,10 +27,18 @@ class GoogleUniversalAnalyticsTest extends PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertSame("<script>
-cxApi.setChosenVariation(1, 'walter');
-ga('send', 'event', 'PhpAb', 'testRun', 'walter', 1);
-cxApi.setChosenVariation(0, 'bernard');
-ga('send', 'event', 'PhpAb', 'testRun', 'bernard', 1);
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(1, 'walter');
+        tracker.send('event', 'PhpAb', 'walter', {'nonInteraction': 1});
+    });
+})();
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(0, 'bernard');
+        tracker.send('event', 'PhpAb', 'bernard', {'nonInteraction': 1});
+    });
+})();
 </script>", $script);
     }
 
@@ -49,10 +57,18 @@ ga('send', 'event', 'PhpAb', 'testRun', 'bernard', 1);
         // Assert
         $this->assertSame("<script src=\"//www.google-analytics.com/cx/api.js\"></script>
 <script>
-cxApi.setChosenVariation(1, 'walter');
-ga('send', 'event', 'PhpAb', 'testRun', 'walter', 1);
-cxApi.setChosenVariation(0, 'bernard');
-ga('send', 'event', 'PhpAb', 'testRun', 'bernard', 1);
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(1, 'walter');
+        tracker.send('event', 'PhpAb', 'walter', {'nonInteraction': 1});
+    });
+})();
+(function(){
+    ga(function(tracker) {
+        cxApi.setChosenVariation(0, 'bernard');
+        tracker.send('event', 'PhpAb', 'bernard', {'nonInteraction': 1});
+    });
+})();
 </script>", $script);
     }
 

--- a/tests/Engine/EngineTest.php
+++ b/tests/Engine/EngineTest.php
@@ -322,12 +322,12 @@ class EngineTest extends \PHPUnit_Framework_TestCase
 
         $engine = new Engine($manager, $dispatcher, $filter, $chooser);
 
-        $test = new Test('foo_test');
+        $test = new Test('foo_test', [], [Google::EXPERIMENT_ID => 'EXPID1']);
         $test->addVariant(new SimpleVariant('_control'));
         $test->addVariant(new SimpleVariant('v1'));
         $test->addVariant(new SimpleVariant('v2'));
 
-        $test2 = new Test('bar_test');
+        $test2 = new Test('bar_test', [], [Google::EXPERIMENT_ID => 'EXPID2']);
         $test2->addVariant(new SimpleVariant('_control'));
         $test2->addVariant(new SimpleVariant('v1'));
 
@@ -342,8 +342,8 @@ class EngineTest extends \PHPUnit_Framework_TestCase
         // Assert
         $this->assertSame(
             [
-                'foo_test' => 1,
-                'bar_test' => 0
+                'EXPID1' => 1,
+                'EXPID2' => 0
             ],
             $testData
         );

--- a/tests/Test/TestTest.php
+++ b/tests/Test/TestTest.php
@@ -208,4 +208,24 @@ class TestTest extends PHPUnit_Framework_TestCase
         // Assert
         $this->assertNull($result);
     }
+
+    /**
+     * Testing that options passed in constructor are returned by getOptions
+     */
+    public function testGetOptions()
+    {
+        // Arrange
+        $options = [
+            'key1' => 'val1',
+            'key2' => 'val2'
+        ];
+
+        $test = new Test('identifier', [], $options);
+
+        // Act
+        $result = $test->getOptions();
+
+        // Assert
+        $this->assertSame($options, $result);
+    }
 }


### PR DESCRIPTION
As discussed, in order to keep test names readable when you implement Google Analytics, we pass the Experiment ID as an element in the new $options array.

I wanted to accept or discard this ASAP since we're writing the docs these days.
